### PR TITLE
Including device labels in NotificationViewModel

### DIFF
--- a/pkg/samples.go
+++ b/pkg/samples.go
@@ -282,6 +282,18 @@ var TestAlarm = &NotificationViewModel{
 					Tag:   "dimension",
 				},
 				&EventViewModelDetail{
+					Name:  "i_device_id",
+					Label: "Device ID",
+					Value: 1234,
+					Tag: "device",
+				},
+				&EventViewModelDetail{
+					Name:  "i_device_labels",
+					Label: "Device Labels",
+					Value: "ACME1, ACME2",
+					Tag: "device_labels",
+				},
+				&EventViewModelDetail{
 					Name:  "DashboardAlarmURL",
 					Label: "Open in Dashboard",
 					Value: "https://portal.kentik.com/v4/library/dashboards/49",

--- a/templates/plain.json.tmpl
+++ b/templates/plain.json.tmpl
@@ -6,6 +6,8 @@
       {{- .Details.General.ToMap | j | x -}},
       "Metrics": {{- (.Details.WithTag "metric").ToMap | j -}},
       "Dimensions": {{- (.Details.WithTag "dimension").ToMap | j -}},
+      "Devices": {{- (.Details.WithTag "device").ToMap | j -}},
+      "DeviceLabels": {{- (.Details.WithTag "device_labels").ToMap | j -}},
       "Links": {{- (.Details.WithTag "url").ToMap | j -}}
     {{- end -}}
   {{- else -}}
@@ -17,6 +19,8 @@
         {{- .Details.General.ToMap | j | x -}},
         "Metrics": {{- (.Details.WithTag "metric").ToMap | j -}},
         "Dimensions": {{- (.Details.WithTag "dimension").ToMap | j -}},
+        "Devices": {{- (.Details.WithTag "device_labels").ToMap | j -}},
+        "DeviceLabels": {{- (.Details.WithTag "device_labels").ToMap | j -}},
         "Links": {{- (.Details.WithTag "url").ToMap | j -}}
       }
     {{- end -}}


### PR DESCRIPTION
Proposal for including device labels in `NotificationViewModel`. 

The updated example renders as:
```json
{
...
  "Devices": {
    "i_device_id": 1234
  },
  "DeviceLabels": {
    "i_device_labels": "ACME1, ACME2"
  },
...
}
```

Choosing to store the labels as a single string containing a comma separated list. This is because the `Value` field only accepts primitive types and the following can break some clients:
```
&EventViewModelDetail{
	Name:  "i_device_labels",
	Label: "Device Labels",
	Value: ["ACME1", "ACME2"],
	Tag: "device_labels",
},
```

https://github.com/kentik/custom-notification-templates/blob/19bf424860f0d77ca477d8ae10d47dd4cbc68132/docs/TEMPLATING_REFERENCE.md?plain=1#L203
