### PR TITLE
Add slack attachment template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@
 vendor/
 
 # Output directory files
-output/*.json
+output/

--- a/pkg/functions.go
+++ b/pkg/functions.go
@@ -23,6 +23,10 @@ var TextTemplateFuncMap = template.FuncMap{
 	"timeRfc3339":     timeRfc3339,
 	"join":            join,
 	"joinWith":        joinWith,
+
+	"importanceLabel":   importanceLabel,
+	"importanceToColor": importanceToColor,
+	"importanceToEmoji": importanceToEmoji,
 }
 
 func tryParseTime(input string) (time.Time, error) {
@@ -111,4 +115,29 @@ func explodeJSONKeys(s string) string {
 		return compacted[1 : len(compacted)-1]
 	}
 	return "explodeJSONKeysErr"
+}
+
+func importanceToColor(severity ViewModelImportance) string {
+	if color, ok := ImportanceToColors[severity]; ok {
+		return color
+	}
+	return ""
+}
+
+func importanceName(severity ViewModelImportance) string {
+	if label, ok := ImportanceNames[severity]; ok {
+		return label
+	}
+	return ""
+}
+
+func importanceLabel(severity ViewModelImportance) string {
+	return strings.Title(importanceName(severity))
+}
+
+func importanceToEmoji(severity ViewModelImportance) string {
+	if emoji, ok := ImportanceToEmojis[severity]; ok {
+		return emoji
+	}
+	return ""
 }

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -41,6 +41,39 @@ var VieModelImportanceOrdered = [...]ViewModelImportance{
 	ViewModelImportance_None,
 }
 
+var ImportanceNames = map[ViewModelImportance]string{
+	ViewModelImportance_None:     "n/a",
+	ViewModelImportance_Healthy:  "healthy",
+	ViewModelImportance_Notice:   "notice",
+	ViewModelImportance_Minor:    "minor",
+	ViewModelImportance_Warning:  "warning",
+	ViewModelImportance_Major:    "major",
+	ViewModelImportance_Severe:   "severe",
+	ViewModelImportance_Critical: "critical",
+}
+
+var ImportanceToColors = map[ViewModelImportance]string{
+	ViewModelImportance_None:     "#999999",
+	ViewModelImportance_Healthy:  "#1E9E1E",
+	ViewModelImportance_Notice:   "#157FF3",
+	ViewModelImportance_Minor:    "#F29D49",
+	ViewModelImportance_Warning:  "#EE7E0F",
+	ViewModelImportance_Major:    "#DB3737",
+	ViewModelImportance_Severe:   "#C23030",
+	ViewModelImportance_Critical: "#A82A2A",
+}
+
+var ImportanceToEmojis = map[ViewModelImportance]string{
+	ViewModelImportance_None:     "",
+	ViewModelImportance_Healthy:  ":warning:",
+	ViewModelImportance_Notice:   ":warning:",
+	ViewModelImportance_Minor:    ":warning:",
+	ViewModelImportance_Warning:  ":warning:",
+	ViewModelImportance_Major:    ":warning:",
+	ViewModelImportance_Severe:   ":warning:",
+	ViewModelImportance_Critical: ":warning:",
+}
+
 // use "export" key instead of standard json key when marshalling/unmarshalling using jsoniter (https://github.com/json-iterator/go),
 // so fields are not removed per standard json tag
 type EventViewModel struct {

--- a/templates/slack-legacy-colorbar.json.tmpl
+++ b/templates/slack-legacy-colorbar.json.tmpl
@@ -1,0 +1,146 @@
+{{- /* This slack template renders colored bars on the left-hand side of messages by "hacking" the
+messages to add an attachment for each message that is to have a different colored bar. The
+attachment element has been deprectated by Slack and could be removed at any time so use this
+template at your own risk.
+
+See Slack docs:
+https://api.slack.com/messaging/webhooks
+https://api.slack.com/block-kit
+
+Documentation regarding this hack:
+https://api.slack.com/messaging/attachments-to-blocks#direct_equivalents Search for "color" on that page.
+https://api.slack.com/reference/messaging/attachments Search for "color" on this page too.
+*/ -}}
+
+{{- /*
+Slack:
+0) if explicit to do digest, do that
+1) if one custom insight, display with old style (like alarms)
+2) if only insights, display as a digest
+*/ -}}
+{{- with .Event -}}
+{
+  "attachments": [
+    {
+      "color": "{{- importanceToColor .Importance -}}",
+      "blocks": [
+        {
+          "type": "divider"
+        },
+        {
+          "type": "header",
+          "text": {
+            "type": "plain_text",
+            "emoji": true,
+            "text": "
+              {{- importanceToEmoji .Importance }} {{ importanceLabel .Importance -}}\n{{- $.Summary -}}
+              {{- range $index, $label := (.Details.WithTag "label").Values -}}
+                {{ " " }}[{{- $label.Name -}}]
+              {{- end -}}
+            "
+          }
+        },
+        {
+          "type": "context",
+          "elements": [
+            {
+              "type": "mrkdwn",
+              "text": "{{ $.Headline }} for *{{ $.CompanyName }}* sent on {{ $.NowDatetime }}"
+            }
+          ]
+        },
+        {
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": "
+              {{- if not .IsInsight -}}
+                *State:* {{ .PreviousState }} → *{{ .CurrentState }}*\n*Timeframe:* {{ .StartTime }} (start) → *{{ .EndTime }}*\n
+              {{- end -}}
+              {{- range $index, $detail := .Details.General -}}
+                *{{ $detail.LabelOrName }}*: {{ $detail.Value }}\n
+              {{- end -}}
+              {{- with $dimensions := .Details.WithTag "dimension" -}}
+                {{- if gt (len $dimensions) 0 -}}
+                  *Dimensions*:\n
+                  {{- range $index, $detail := $dimensions -}}
+                    {{- if (and (eq "i_device_id" $detail.Name) ($.Event.Details.Has "DeviceName")) -}}
+                      - *Device*: {{ $.Event.Details.GetValue "DeviceName" -}}
+                        {{- if $.Event.Details.Has "DeviceType" }} ({{ $.Event.Details.GetValue "DeviceType" }}) {{ end -}}
+                        {{- range $index, $label := ($.Event.Details.WithTag "device_label").Values -}}
+                          [{{- $label.Name -}}]
+                        {{- end -}}
+                        {{- "\\n" -}}
+                    {{- else -}}
+                      - *{{ $detail.LabelOrName }}*: {{ $detail.Value }}\n
+                    {{- end -}}
+                  {{- end -}}
+                {{- end -}}
+              {{- end -}}
+              {{- with $metrics:= .Details.WithTag "metric" -}}
+                {{- if gt (len $metrics) 0 -}}
+                  *Metrics*:\n
+                  {{- range $index, $metric := $metrics -}}
+                    - {{ $metric.Value }} {{ $metric.LabelOrName }}\n
+                  {{- end -}}
+                {{- end -}}
+              {{- end -}}
+              {{- with $stats := .Details.WithTag "statistic" -}}
+                {{- if gt (len $stats) 0 -}}
+                  *Summary*:\n
+                  {{- range $index, $detail := $stats -}}
+                    - *{{ $detail.LabelOrName }}*: {{ $detail.Value }}\n
+                  {{- end -}}
+                {{- end -}}
+              {{- end -}}
+              {{- with $issues := (.Details.WithTag "issue").Values -}}
+                {{- if gt (len $issues) 0 -}}
+                  *Issues*:\n
+                  {{- range $index, $issue := $issues -}}
+                    - {{ range $index, $label := $issue.Labels -}}
+                        [{{- $label.Name -}}]{{ " " }}
+                      {{- end -}}
+                      *{{ $issue.Description }}*
+                      {{- if $issue.DetailedInfo }}: {{ end -}}
+                      {{- range $index, $detailedItem := $issue.DetailedInfo -}}
+                        {{- joinWith $index ", " -}}
+                        {{- $detailedItem -}}
+                      {{- end -}}
+
+                      {{- if $issue.Url -}}
+                      {{- " " }}- <{{ $issue.Url }}|{{ if $issue.UrlLabel }}{{ $issue.UrlLabel }}{{ else }}More details{{ end }} »>
+                      {{- end -}}
+                      \n
+                  {{- end -}}
+                {{- end -}}
+              {{- end -}}
+            "
+          }
+        },
+        {
+          "type": "actions",
+          "elements": [
+            {{- range $index, $url := .Details.WithTag "url" -}}
+            {{- join $index -}}
+            {
+              "type": "button",
+              "action_id": "{{- $url.Name -}}",
+              "text": {
+                "type": "plain_text",
+                "text": "{{- $url.LabelOrName -}}"
+              },
+              "url": "{{ $url.Value }}"
+            }
+            {{- end -}}
+          ]
+        }
+      ]
+    }
+  ]
+}
+{{- end -}}
+
+{{- /*
+Note: In this v1 channel, only one event is expected to be sent at a time,
+so there is no case for multiple events.
+*/ -}}


### PR DESCRIPTION
Adds a slack template that uses the legacy `attachment` element to enable the rendering of a colored bar to the left of the message.